### PR TITLE
Update openregister-ruby to v0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'haml-rails'
 gem 'govuk_template'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_elements_rails'
-gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby-client', :tag => 'v0.1.0'
+gem 'openregister-ruby', git: 'https://github.com/openregister/openregister-ruby-client', :tag => 'v0.2.1'
 gem 'httparty'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GIT
   remote: https://github.com/openregister/openregister-ruby-client
-  revision: 6769a5123d30bc800a40f39a08072fa3be6b31ce
-  tag: v0.1.0
+  revision: 8924f3b8cbb76548f334bb66c8cb9010634366f2
+  tag: v0.2.1
   specs:
-    openregister-ruby (0.1.0)
+    openregister-ruby (0.2.1)
+      mini_cache (~> 1.1.0)
       morph (~> 0.5.0)
       rest-client (~> 2)
 
@@ -104,6 +105,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_cache (1.1.0)
     mini_portile2 (2.2.0)
     minitest (5.10.3)
     morph (0.5.1)

--- a/app/controllers/registers_controller.rb
+++ b/app/controllers/registers_controller.rb
@@ -15,7 +15,7 @@ class RegistersController < ApplicationController
   end
 
   def entries
-    register = @registers_client.get_register(params[:register], 'beta')
+    register = @@registers_client.get_register(params[:register], 'beta')
 
     fields = register.get_field_definitions.map{|field| field[:item]['field']}
     all_records = register.get_records_with_history
@@ -51,7 +51,7 @@ class RegistersController < ApplicationController
     @register_name = params[:register]
     @register_phase = params[:phase]
 
-    register = @registers_client.get_register(@register_name, @register_phase)
+    register = @@registers_client.get_register(@register_name, @register_phase)
 
     @records = []
 
@@ -113,7 +113,7 @@ class RegistersController < ApplicationController
   private
 
   def initialize_client
-    @registers_client = OpenRegister::RegistersClient.new
+    @@registers_client ||= OpenRegister::RegistersClient.new({ cache_duration: 3600 })
   end
 
   def register_params


### PR DESCRIPTION
This PR updates the openregister-ruby gem to v0.2.1 and stores the `RegistersClient` object as a class variable to ensure we get the benefits of the new caching in the client library. It also sets the cache duration to one hour - the period after which new data is allowed to be retrieved for a register.